### PR TITLE
Update ovn paths post ovn split

### DIFF
--- a/bindata/network/ovn-kubernetes/ovnkube-master.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-master.yaml
@@ -33,9 +33,9 @@ spec:
       priorityClassName: "system-cluster-critical"
       # volumes in all containers:
       # (container) -> (host)
-      # /etc/openvswitch -> /var/lib/ovn/etc - ovsdb data
-      # /var/lib/openvswitch -> /var/lib/ovn/data - ovsdb pki state
-      # /run/openvswitch -> tmpfs - sockets & pids
+      # /etc/ovn -> /var/lib/ovn/etc - ovsdb data
+      # /var/lib/ovn -> /var/lib/ovn/data - ovsdb pki state
+      # /run/ovn -> tmpfs - sockets & pids
       # /env -> configmap env-overrides - debug overrides
       containers:
       # ovn-northd: convert network objects in nbdb to flows in sbdb
@@ -51,17 +51,17 @@ spec:
             source /env/_master
             set +o allexport
           fi
-          exec ovn-northd --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off --pidfile=/var/run/openvswitch/ovn-northd.pid
+          exec ovn-northd --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off --pidfile=/var/run/ovn/ovn-northd.pid
         env:
         - name: OVN_LOG_LEVEL
           value: info
         volumeMounts:
-        - mountPath: /etc/openvswitch/
-          name: etc-openvswitch
-        - mountPath: /var/lib/openvswitch/
-          name: var-lib-openvswitch
-        - mountPath: /run/openvswitch/
-          name: run-openvswitch
+        - mountPath: /etc/ovn/
+          name: etc-ovn
+        - mountPath: /var/lib/ovn/
+          name: var-lib-ovn
+        - mountPath: /run/ovn/
+          name: run-ovn
         - mountPath: /env
           name: env-overrides
         resources:
@@ -82,7 +82,7 @@ spec:
             source /env/_master
             set +o allexport
           fi
-          exec /usr/share/openvswitch/scripts/ovn-ctl run_nb_ovsdb \
+          exec /usr/share/ovn/scripts/ovn-ctl run_nb_ovsdb \
             --no-monitor \
             --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off"
         lifecycle:
@@ -105,12 +105,12 @@ spec:
         - name: OVN_LOG_LEVEL
           value: info
         volumeMounts:
-        - mountPath: /etc/openvswitch/
-          name: etc-openvswitch
-        - mountPath: /var/lib/openvswitch/
-          name: var-lib-openvswitch
-        - mountPath: /run/openvswitch/
-          name: run-openvswitch
+        - mountPath: /etc/ovn/
+          name: etc-ovn
+        - mountPath: /var/lib/ovn/
+          name: var-lib-ovn
+        - mountPath: /run/ovn/
+          name: run-ovn
         - mountPath: /env
           name: env-overrides
         resources:
@@ -131,7 +131,7 @@ spec:
             source "/env/_master"
             set +o allexport
           fi
-          exec /usr/share/openvswitch/scripts/ovn-ctl run_sb_ovsdb \
+          exec /usr/share/ovn/scripts/ovn-ctl run_sb_ovsdb \
             --no-monitor \
             --ovn-nb-log="-vconsole:${OVN_LOG_LEVEL} -vfile:off"
         env:
@@ -154,12 +154,12 @@ spec:
                   sleep 2
                 done
         volumeMounts:
-        - mountPath: /etc/openvswitch/
-          name: etc-openvswitch
-        - mountPath: /var/lib/openvswitch/
-          name: var-lib-openvswitch
-        - mountPath: /run/openvswitch/
-          name: run-openvswitch
+        - mountPath: /etc/ovn/
+          name: etc-ovn
+        - mountPath: /var/lib/ovn/
+          name: var-lib-ovn
+        - mountPath: /run/ovn/
+          name: run-ovn
         - mountPath: /env
           name: env-overrides
 
@@ -196,12 +196,12 @@ spec:
             --logfile /dev/stdout \
             --metrics-bind-address "0.0.0.0:9102"
         volumeMounts:
-        - mountPath: /etc/openvswitch/
-          name: etc-openvswitch
-        - mountPath: /var/lib/openvswitch/
-          name: var-lib-openvswitch
-        - mountPath: /run/openvswitch/
-          name: run-openvswitch
+        - mountPath: /etc/ovn/
+          name: etc-ovn
+        - mountPath: /var/lib/ovn/
+          name: var-lib-ovn
+        - mountPath: /run/ovn/
+          name: run-ovn
         - mountPath: /env
           name: env-overrides
         resources:
@@ -236,13 +236,13 @@ spec:
         node-role.kubernetes.io/master: ""
         beta.kubernetes.io/os: "linux"
       volumes:
-      - name: etc-openvswitch
+      - name: etc-ovn
         hostPath:
           path: /var/lib/ovn/etc
-      - name: var-lib-openvswitch
+      - name: var-lib-ovn
         hostPath:
           path: /var/lib/ovn/data
-      - name: run-openvswitch
+      - name: run-ovn
         emptyDir: {}
       - name: env-overrides
         configMap:

--- a/bindata/network/ovn-kubernetes/ovnkube-node.yaml
+++ b/bindata/network/ovn-kubernetes/ovnkube-node.yaml
@@ -82,6 +82,8 @@ spec:
           readOnly: true
         - mountPath: /run/openvswitch
           name: run-openvswitch
+        - mountPath: /run/ovn
+          name: run-ovn
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
         - mountPath: /old/openvswitch
@@ -129,7 +131,7 @@ spec:
             set +o allexport
           fi
           exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
-            --no-chdir --pidfile=/var/run/openvswitch/ovn-controller.pid \
+            --no-chdir --pidfile=/var/run/ovn/ovn-controller.pid \
             -vconsole:"${OVN_LOG_LEVEL}"
         securityContext:
           privileged: true
@@ -143,6 +145,8 @@ spec:
         volumeMounts:
         - mountPath: /run/openvswitch
           name: run-openvswitch
+        - mountPath: /run/ovn
+          name: run-ovn
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
         - mountPath: /var/lib/openvswitch
@@ -259,6 +263,8 @@ spec:
           name: host-var-lib-cni-networks-ovn-kubernetes
         - mountPath: /run/openvswitch
           name: run-openvswitch
+        - mountPath: /run/ovn
+          name: run-ovn
         - mountPath: /etc/openvswitch
           name: etc-openvswitch
         - mountPath: /var/lib/openvswitch
@@ -305,6 +311,8 @@ spec:
       # commit 0ac2cd changed the location of the ovs database, mount and check if a database already exists
       - name: old-openvswitch-database
         path: /etc/origin/openvswitch
+      - name: run-ovn
+        emptyDir: {}
       # For CNI server
       - name: host-run-ovn-kubernetes
         hostPath:


### PR DESCRIPTION
I'm testing with an ovn-kube build that includes OVN from after it was
split out from OVS.  Many of the paths that used to include
"openvswitch" are now "ovn" by default instead.